### PR TITLE
Do not force a connection link in main_menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@ No 'site_path'
 A DupalGap module.
 
 For all information, please see http://drupalgap.org/project/nositepath
+
+## settings.js
+
+If you would like to have a link to the connection form then add the following
+snippet to the list of links defined as part of
+`drupalgap.settings.menus['main_menu']` in your settings.js file:
+
+```
+{
+  title: 'Connection',
+  path: 'nositepath',
+  options: {
+    attributes: {'data-icon': 'gear'}
+  },
+},

--- a/nositepath.js
+++ b/nositepath.js
@@ -8,31 +8,6 @@ if (!Drupal.settings.site_path || Drupal.settings.site_path == '') {
   Drupal.settings.site_path = variable_get('nositepath_site_path', nositepath_temp_path);
 }
 
-// Add the menu item. @TODO Should probably happen in nositepath_deviceready().
-nositepath_add_menu_item();
-
-/**
- * Add main_menu item.
- */
-function nositepath_add_menu_item() {
-  // Check to see if it's already been added. @TODO This is a silly hack.
-  for (var i = 0; i < drupalgap.settings.menus['main_menu'].links.length; i++) {
-    if (drupalgap.settings.menus['main_menu'].links[i].path == 'nositepath') {
-      return true;
-    }
-  }
-  // Add the Connection menu item.
-  drupalgap.settings.menus['main_menu'].links.push(
-          {
-            title: 'Connection',
-            path: 'nositepath',
-            options: {
-              attributes: {'data-icon': 'gear'}
-            },
-          }
-  );
-}
-
 /**
  * Implements hook_deviceready().
  */


### PR DESCRIPTION
It seems like menu links should be chosen by settings.js.  This removes the code for adding the link and adds information about how to add it in README.md.